### PR TITLE
Ignore /build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Built application files
 /*/build/
+/build
 
 # Crashlytics configuations
 com_crashlytics_export_strings.xml


### PR DESCRIPTION
Ignore /build directory.
This is a default in the Android Studio .gitignore file.