### PR TITLE
Don't crash when Yarra builds new tram stops

### DIFF
--- a/app/src/main/java/com/andybotting/tramhunter/activity/StopDetailsActivity.java
+++ b/app/src/main/java/com/andybotting/tramhunter/activity/StopDetailsActivity.java
@@ -262,15 +262,14 @@ public class StopDetailsActivity extends AppCompatActivity {
 		if(mStop==null){
 			//YT has built another new tram stop since last DB update
 			mStop = new Stop();
+			mStop.setId(Stop.ID_MISSING);
 			mStop.setTramTrackerID(mTramTrackerId);
 			mStop.setPrimaryName(String.format("Unknown stop (%d)", mTramTrackerId));
 		}
 		if (routeId > -1)
 			mRoute = mDB.getRoute(routeId);
 
-		// Set the title
-		final String title = mStop.getStopName();
-		actionBar.setTitle(title);
+
 
 		// Display stop data
 		displayStop(mStop);
@@ -324,6 +323,9 @@ public class StopDetailsActivity extends AppCompatActivity {
 
 		if (mRefreshThread.isInterrupted())
 			mRefreshThread.start();
+
+		if(mStop.getId()==Stop.ID_MISSING) //-1 means not in our db, -2 means already loaded from network.
+			new GetStopDetails().execute(mStop.getTramTrackerID());
 
 		// Force update of tram times to prevent stale times if the app
 		// is opened again
@@ -475,6 +477,12 @@ public class StopDetailsActivity extends AppCompatActivity {
 		String stopDetails = stop.getStopDetailsLine();
 		String stopRoutes = stop.getRoutesString();
 
+		// Set the title
+		ActionBar actionBar = getSupportActionBar();
+		final String title = stop.getStopName();
+		actionBar.setTitle(title);
+
+
 		((TextView) findViewById(R.id.stopNameTextView)).setText(stopName);
 		((TextView) findViewById(R.id.stopDetailsTextView)).setText(stopDetails);
 		((TextView) findViewById(R.id.stopRoutesTextView)).setText(stopRoutes);
@@ -567,7 +575,27 @@ public class StopDetailsActivity extends AppCompatActivity {
 		if (!mIsRefreshing)
 			new GetNextTramTimes().execute();
 	}
+	private class GetStopDetails extends AsyncTask<Integer, Void, Stop> {
+		@Override
+		protected Stop doInBackground(Integer... tramTrackerId) {
+			try{
+				Stop newStop = ttService.getStopInformation(mStop.getTramTrackerID());
+				return newStop;
+			}catch (TramTrackerServiceException e){
+				final CharSequence message = getApplicationContext().getString(R.string.dialog_error_fetching_stop_details, mErrorMessage);
+				Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG).show();
+			}
+			return null;
+		}
 
+		@Override
+		protected void onPostExecute(Stop stop) {
+			if(stop!=null){
+				mStop=stop;
+				displayStop(mStop);
+			}
+		}
+	}
 	/**
 	 * Background task for fetching tram times
 	 */
@@ -625,6 +653,7 @@ public class StopDetailsActivity extends AppCompatActivity {
 
 		@Override
 		protected void onPostExecute(List<NextTram> nextTrams) {
+			if(mStop.getId()<0) displayStop(mStop);
 			if (mErrorRetry == MAX_ERRORS) {
 
 				// Toast: Error fetching departure information

--- a/app/src/main/java/com/andybotting/tramhunter/activity/StopDetailsActivity.java
+++ b/app/src/main/java/com/andybotting/tramhunter/activity/StopDetailsActivity.java
@@ -259,6 +259,12 @@ public class StopDetailsActivity extends AppCompatActivity {
 		// Create out DB instance
 		mDB = new TramHunterDB();
 		mStop = mDB.getStop(mTramTrackerId);
+		if(mStop==null){
+			//YT has built another new tram stop since last DB update
+			mStop = new Stop();
+			mStop.setTramTrackerID(mTramTrackerId);
+			mStop.setPrimaryName(String.format("Unknown stop (%d)", mTramTrackerId));
+		}
 		if (routeId > -1)
 			mRoute = mDB.getRoute(routeId);
 

--- a/app/src/main/java/com/andybotting/tramhunter/objects/Stop.java
+++ b/app/src/main/java/com/andybotting/tramhunter/objects/Stop.java
@@ -43,9 +43,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 
-public class Stop { 
-	
-	private long id = -1;
+public class Stop {
+	public static final long ID_MISSING = -1;
+	public static final long ID_LOADED_FROM_NETWORK = -2;
+
+	private long id = ID_MISSING;
 	private int tramTrackerID = -1;
 	private String flagStopNumber;
 	private String primaryName;

--- a/app/src/main/java/com/andybotting/tramhunter/service/TramTrackerServiceJSON.java
+++ b/app/src/main/java/com/andybotting/tramhunter/service/TramTrackerServiceJSON.java
@@ -241,10 +241,14 @@ public class TramTrackerServiceJSON implements TramTrackerService {
 			String flagStopNo = responseObject.getString("FlagStopNo");
 			String stopName = responseObject.getString("StopName");
 			String cityDirection = responseObject.getString("CityDirection");
+			double latitude = responseObject.getDouble("Latitude");
+			double longitude = responseObject.getDouble("Longitude");
 
 			stop.setFlagStopNumber(flagStopNo);
 			stop.setStopName(stopName);
 			stop.setCityDirection(cityDirection);
+			stop.setLatitude(latitude);
+			stop.setLongitude(longitude);
 
 			return stop;
 		} catch (Exception e) {
@@ -259,13 +263,14 @@ public class TramTrackerServiceJSON implements TramTrackerService {
 		try {
 			Stop stop = null;
 
-			// TODO: Update this for JSON
-			String url = BASE_URL + "/GetStopInformation.aspx?s=" + tramTrackerID;
+			String method = "GetStopInformation";
+			String url = String.format("%s/%s/%d/", BASE_URL, method, tramTrackerID);
 			InputStream jsonData = getJSONData(url, null);
 			JSONObject serviceData = parseJSONStream(jsonData);
-			JSONObject responseObject = getResponseObject(serviceData);
-			stop = parseStopInformation(responseObject);
+			JSONArray responseArray = getResponseArray(serviceData);
+			stop = parseStopInformation(responseArray.getJSONObject(0));
 			stop.setTramTrackerID(tramTrackerID);
+			stop.setId(Stop.ID_LOADED_FROM_NETWORK);
 			return stop;
 		} catch (Exception e) {
 			// Throw a TramTrackerServiceException to encapsulate all

--- a/app/src/main/java/com/andybotting/tramhunter/service/TramTrackerServiceJSON.java
+++ b/app/src/main/java/com/andybotting/tramhunter/service/TramTrackerServiceJSON.java
@@ -448,6 +448,12 @@ public class TramTrackerServiceJSON implements TramTrackerService {
 				// Get stop string and fetch stop from DB
 				int stopNumber = timeObject.getInt("StopNo");
 				Stop stop = mDB.getStop(stopNumber);
+				if(stop==null){
+					//YT has built another new tram stop since last DB update
+					stop = new Stop();
+					stop.setTramTrackerID(stopNumber);
+					stop.setPrimaryName(String.format("Unknown stop (%d)", stopNumber));
+				}
 				tramRunTime.setStop(stop);
 
 				// Get predicted time and parse it to a java datetime

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
     <string name="no_favourite_stops">You currently have no favourite tram stops.\n\nTo add favourite tram stops simply click the favourite star when browsing tram stops.\n\nDo you want to browse some now?</string>
 
     <!-- Dialog -->
+    <string name="dialog_error_fetching_stop_details">Error fetching stop details (<xliff:g id="error">%1$s</xliff:g>)</string>
     <string name="dialog_error_fetching">Error fetching departure times (<xliff:g id="error">%1$s</xliff:g>)</string>
     <string name="dialog_set_name">Set stop name</string>
     <string name="dialog_set_name_message">Set a custom name for \'<xliff:g id="name">%1$s</xliff:g>\'</string>


### PR DESCRIPTION
For example, YT build a new tram stop (3022) for rt 58 to Toorak at Toorak Rd.  `TramRunActivity` would crash because the stop was null. Now it will show as `Unknown stop (3022)` instead.

(The other way to fix this is to update the db, remove the Park St and Domain Rd stops, rename stop 1561, insert stop 3022. But stops can only be inserted after YT builds them).