### PR TITLE
homescreen widget for favourite stops

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" />
-
+    <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <!-- Require Android 2.2 -->
     <uses-sdk
         android:minSdkVersion="8"
@@ -122,6 +122,7 @@
         <activity
             android:name=".activity.StopDetailsActivity"
             android:configChanges="orientation|keyboardHidden"
+            android:exported="true"
             android:label="@string/app_name" />
 
         <!-- Tram Run Activity -->

--- a/app/src/main/java/com/andybotting/tramhunter/activity/FavouriteActivity.java
+++ b/app/src/main/java/com/andybotting/tramhunter/activity/FavouriteActivity.java
@@ -57,6 +57,7 @@ import android.widget.HeaderViewListAdapter;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.andybotting.tramhunter.R;
 import com.andybotting.tramhunter.objects.Favourite;
@@ -70,6 +71,7 @@ public class FavouriteActivity extends AppCompatActivity {
 	private final static int CONTEXT_MENU_SET_NAME = 0;
 	private final static int CONTEXT_MENU_VIEW_STOP = 1;
 	private final static int CONTEXT_MENU_UNFAVOURITE = 2;
+	private final static int CONTEXT_MENU_HOMESCREEN_SHORTCUT = 3;
 
 	private FavouritesListAdapter mListAdapter;
 	private FavouriteList mFavourites;
@@ -281,10 +283,11 @@ public class FavouriteActivity extends AppCompatActivity {
 
 			menu.setHeaderIcon(R.drawable.icon);
 			menu.setHeaderTitle(favourite.getName());
-			// TODO: These should be set in strings.xml
+			// TODO: These should be set in strings.xml / menu xml
 			menu.add(0, CONTEXT_MENU_SET_NAME, CONTEXT_MENU_SET_NAME, "Set Stop Name");
 			menu.add(0, CONTEXT_MENU_VIEW_STOP, CONTEXT_MENU_VIEW_STOP, "View Stop");
 			menu.add(0, CONTEXT_MENU_UNFAVOURITE, CONTEXT_MENU_UNFAVOURITE, "Unfavourite Stop");
+			menu.add(0, CONTEXT_MENU_HOMESCREEN_SHORTCUT, CONTEXT_MENU_HOMESCREEN_SHORTCUT, "Create Shortcut");
 		}
 	};
 
@@ -314,9 +317,32 @@ public class FavouriteActivity extends AppCompatActivity {
 				mFavourites.writeFavourites();
 				displayStops();
 				return true;
+			case CONTEXT_MENU_HOMESCREEN_SHORTCUT:
+				createHomescreenShortcut(favourite);
+				return true;
 		}
 
 		return super.onContextItemSelected(item);
+	}
+
+	private void createHomescreenShortcut(Favourite favourite){
+		Intent shortcutIntent = new Intent(this, StopDetailsActivity.class);
+		shortcutIntent.putExtra("tramTrackerId", favourite.getStop().getTramTrackerID());
+		Route route = favourite.getRoute();
+		if (route != null)
+			shortcutIntent.putExtra("routeId", route.getId());
+
+		shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+		shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+
+		final Intent putShortcutIntent = new Intent();
+		putShortcutIntent.putExtra(Intent.EXTRA_SHORTCUT_INTENT, shortcutIntent);
+		putShortcutIntent.putExtra(Intent.EXTRA_SHORTCUT_NAME, favourite.getName());
+		//TODO: create a good icon for this
+		putShortcutIntent.putExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE, Intent.ShortcutIconResource.fromContext(this, R.drawable.star_on));
+		putShortcutIntent.setAction("com.android.launcher.action.INSTALL_SHORTCUT");
+		sendBroadcast(putShortcutIntent);
+		Toast.makeText(this, R.string.toast_creating_homescreen_shortcut, Toast.LENGTH_SHORT).show();
 	}
 
 	/**

--- a/app/src/main/java/com/andybotting/tramhunter/activity/StopDetailsActivity.java
+++ b/app/src/main/java/com/andybotting/tramhunter/activity/StopDetailsActivity.java
@@ -734,7 +734,7 @@ public class StopDetailsActivity extends AppCompatActivity {
 			}
 
 			NextTram thisTram = (NextTram) mNextTrams.get(position);
-			((TextView) pv.findViewById(R.id.routeNumber)).setText(thisTram.getRouteNo());
+			((TextView) pv.findViewById(R.id.routeNumber)).setText(thisTram.getHeadboardRouteNo());
 			((TextView) pv.findViewById(R.id.routeDestination)).setText(thisTram.getDestination());
 			((TextView) pv.findViewById(R.id.nextTime)).setText(thisTram.humanMinutesAway());
 

--- a/app/src/main/java/com/andybotting/tramhunter/activity/StopDetailsActivity.java
+++ b/app/src/main/java/com/andybotting/tramhunter/activity/StopDetailsActivity.java
@@ -43,6 +43,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.support.v4.view.MenuItemCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -458,9 +459,9 @@ public class StopDetailsActivity extends AppCompatActivity {
 					LayoutInflater inflater = (LayoutInflater) this.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 					mRefreshIndeterminateProgressView = inflater.inflate(R.layout.actionbar_progress, mListView, false);
 				}
-				mRefreshItem.setActionView(mRefreshIndeterminateProgressView);
+				MenuItemCompat.setActionView(mRefreshItem, mRefreshIndeterminateProgressView);
 			} else {
-				mRefreshItem.setActionView(null);
+				MenuItemCompat.setActionView(mRefreshItem, null);
 			}
 		}
 	}

--- a/app/src/main/java/com/andybotting/tramhunter/activity/TramRunActivity.java
+++ b/app/src/main/java/com/andybotting/tramhunter/activity/TramRunActivity.java
@@ -40,6 +40,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.support.v4.view.MenuItemCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -294,9 +295,9 @@ public class TramRunActivity extends AppCompatActivity {
 					LayoutInflater inflater = (LayoutInflater) this.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 					mRefreshIndeterminateProgressView = inflater.inflate(R.layout.actionbar_progress, null);
 				}
-				mRefreshItem.setActionView(mRefreshIndeterminateProgressView);
+				MenuItemCompat.setActionView(mRefreshItem, mRefreshIndeterminateProgressView);
 			} else {
-				mRefreshItem.setActionView(null);
+				MenuItemCompat.setActionView(mRefreshItem, null);
 			}
 		}
 	}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,7 +112,7 @@
     <string name="notification_title">Your tram is approaching</string>
     <string name="notification_message">Your tram is approaching</string>
     <string name="dialog_error_msg">Please enter a valid number</string>
-    <string name="dialog_notification_trigger_msg">You will be alerted <xliff:g id="name">%1$s</xliff:g> minute(s) before your tram is due</string>
+    <string name="dialog_notification_trigger_msg">You will be alerted <xliff:g id="name">%1$d</xliff:g> minute(s) before your tram is due</string>
 
     <!-- Toast -->
     <string name="toast_favourite_added">Added to favourite stops.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="toast_favourite_added">Added to favourite stops.</string>
     <string name="toast_favourite_removed">Removed from favourite stops.</string>
     <string name="toast_unable_closest_stop">Unable to determine closest favourite stop.</string>
+    <string name="toast_creating_homescreen_shortcut">Creating shortcut. Press Home key to view.</string>
 
     <!-- Other -->
     <string name="tram_quote">Tram Quote</string>


### PR DESCRIPTION
Feature: homescreen widget for favourite stops
Add a homescreen widget/shortcut to a favourite stop to your homescreen, via the favourites context menu. This will need a new icon, at the moment it's using a very blurry star!

Future enhancement: support android 7.1 app shortcuts (by pressing on the launcher icon)

Also:
-Use headboardRouteNumber instead of routeNo so it shows route 3a instead of 4 (which you can only notice on weekends!)
-Fix some lint issues with menu item action view (would cause issues on Android<11)

