### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/near_stops_list_row.xml
+++ b/app/src/main/res/layout/near_stops_list_row.xml
@@ -48,7 +48,7 @@
 
 	<TextView android:id="@+id/stop_distance"
 		style="@style/ListSubtitle"
-		android:textColor="@color/aqua"
+		android:textColor="#0064FF"
 		android:layout_width="wrap_content"
     	android:layout_height="wrap_content"
     	android:layout_alignParentRight="true" />	


### PR DESCRIPTION
The original text color of the component is '#EBEBEB', and the contrast between the text color ('#ECECEC') and the background color ('#007BFF') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#0064FF') are as follows:
![image](https://user-images.githubusercontent.com/101503193/211331742-a583f2cc-772d-4332-8dc5-bc1030e6483d.png)

The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.